### PR TITLE
Add explanation for obtaining OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ To run the transcription script, follow these steps:
    pip install -r requirements.txt
    ```
 
-2. Run the transcription script:
+2. Set the `OPENAI_API_KEY` environment variable:
+   ```bash
+   export OPENAI_API_KEY='your_openai_api_key'
+   ```
+
+3. Run the transcription script:
    ```bash
    python transcribe.py
    ```
 
-The script will print the transcription text to the console.
+The script requires the `OPENAI_API_KEY` to be set in order to work. The script will print the transcription text to the console.


### PR DESCRIPTION
Add instructions for setting the OpenAI API key in the README.md file.

* Add a step to set the `OPENAI_API_KEY` environment variable before running the transcription script.
* Mention that the `OPENAI_API_KEY` is required for the script to work.
* Update the numbering of the steps accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/roryp/openai/pull/2?shareId=ab4cd889-c702-4577-9da0-e0d01eb39504).